### PR TITLE
fix: remove cuda dependency, and bump minimal jax version allowed

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Different installation versions:
 4. To build docs, install `mjinx[docs]`
 5. To install the repository with all dependencies, install `mjinx[all]`
 
+Note that by default installation of `mjinx` installs `jax` without cuda support. If you need it, please install `jax>=0.5.0` with CUDA support manually.
+
 ## Usage
 Here is the example of `mjinx` usage:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
   "mujoco",
   "mujoco_mjx",
   "jaxopt",
-  "jax[cuda]>=0.4",
+  "jax>=0.5",
   "jaxlie>=1.4",
   "jax_dataclasses>=1.6.0",
   "optax>=0.2",


### PR DESCRIPTION
This PR fixes the problem with jax dependency mentioned in #39. 

From now on, explicit dependency on cuda in jax is removed; users are required to manually install `jax[cuda]>=0.5.0` if required.